### PR TITLE
Update URL from herokuapp.com to fly.dev on website and README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,24 +17,24 @@ _All routes are GET routes_
 * **`GET /api/v1/characters`** - get all characters (default 20 per page / 497 total characters)
 * **`GET /api/v1/characters?perPage=<number>&page=<number>`** - pagination now available!
   * pagination is also available on other endpoints below
-  * example: [GET /api/v1/characters?perPage=10&page=5](https://last-airbender-api.herokuapp.com/api/v1/characters?perPage=10&page=5)
+  * example: [GET /api/v1/characters?perPage=10&page=5](https://last-airbender-api.fly.dev/api/v1/characters?perPage=10&page=5)
 * **`GET /api/v1/characters/<character_id>`** - get character by id
-  * example: [GET /api/v1/characters/5cf5679a915ecad153ab68cc](https://last-airbender-api.herokuapp.com/api/v1/characters/5cf5679a915ecad153ab68cc)
+  * example: [GET /api/v1/characters/5cf5679a915ecad153ab68cc](https://last-airbender-api.fly.dev/api/v1/characters/5cf5679a915ecad153ab68cc)
 * **`GET /api/v1/characters?affiliation=<nation+name>`** - get characters with a specific affiliation
   * choices: "Fire Nation", "Water Tribe", "Earth Kingdom", "Air Nomads", "Team Avatar", and more!
-  * example: [GET /api/v1/characters?affiliation=Fire+Nation](https://last-airbender-api.herokuapp.com/api/v1/characters?affiliation=Fire+Nation)
+  * example: [GET /api/v1/characters?affiliation=Fire+Nation](https://last-airbender-api.fly.dev/api/v1/characters?affiliation=Fire+Nation)
 * **`GET /api/v1/characters?enemies=<character+name>`** - get characters that are enemies of a specific character
-  * example: [GET /api/v1/characters?enemies=Aang](https://last-airbender-api.herokuapp.com/api/v1/characters?enemies=Aang)
+  * example: [GET /api/v1/characters?enemies=Aang](https://last-airbender-api.fly.dev/api/v1/characters?enemies=Aang)
 * **`GET /api/v1/characters?allies=<character+name>`** - get characters who are allies of a specific character
-  * example: [GET /api/v1/characters?allies=Aang](https://last-airbender-api.herokuapp.com/api/v1/characters?allies=Aang)
+  * example: [GET /api/v1/characters?allies=Aang](https://last-airbender-api.fly.dev/api/v1/characters?allies=Aang)
 * **`GET /api/v1/characters?name=<character+name>`** - get characters whose name matches a string
-  * example: [GET /api/v1/characters?name=Aang](https://last-airbender-api.herokuapp.com/api/v1/characters?name=Aang)
+  * example: [GET /api/v1/characters?name=Aang](https://last-airbender-api.fly.dev/api/v1/characters?name=Aang)
 * **`GET /api/v1/characters/random`** - get one random character
-  * example: [GET /api/v1/characters/random](https://last-airbender-api.herokuapp.com/api/v1/characters/random)
+  * example: [GET /api/v1/characters/random](https://last-airbender-api.fly.dev/api/v1/characters/random)
 * **`GET /api/v1/characters/random?count=<number>`** - get a number of random characters
-  * example: [GET /api/v1/characters/random?count=5](https://last-airbender-api.herokuapp.com/api/v1/characters/random?count=5)
+  * example: [GET /api/v1/characters/random?count=5](https://last-airbender-api.fly.dev/api/v1/characters/random?count=5)
 * **`GET /api/v1/characters/avatar`** - get all avatars
-  * example: [GET /api/v1/characters/avatar](https://last-airbender-api.herokuapp.com/api/v1/characters/avatar)
+  * example: [GET /api/v1/characters/avatar](https://last-airbender-api.fly.dev/api/v1/characters/avatar)
 
 ## Error Conditions
 

--- a/lib/Public/index.html
+++ b/lib/Public/index.html
@@ -24,49 +24,49 @@
       </tr>
       <tr>
         <td class="route">
-          <div class ="example-link"><a href="https://last-airbender-api.herokuapp.com/api/v1/characters">example</a></div>
+          <div class ="example-link"><a href="https://last-airbender-api.fly.dev/api/v1/characters">example</a></div>
           <span>GET /api/v1/characters <br /></span>
         </td>
         <td>get all characters (default 20 per page)<br /></td>
       </tr>
       <tr>
         <td class="route">
-          <div class ="example-link"><a href="https://last-airbender-api.herokuapp.com/api/v1/characters?perPage=10&page=5">example</a></div>
+          <div class ="example-link"><a href="https://last-airbender-api.fly.dev/api/v1/characters?perPage=10&page=5">example</a></div>
           <span>GET /api/v1/characters?perPage=NUMBER&page=NUMBER <br /></span>
         </td>
         <td>get all characters pagination<br /></td>
       </tr>
       <tr>
         <td class="route">
-          <div class ="example-link"><a href="https://last-airbender-api.herokuapp.com/api/v1/characters/5cf5679a915ecad153ab68cc">example</a></div>
+          <div class ="example-link"><a href="https://last-airbender-api.fly.dev/api/v1/characters/5cf5679a915ecad153ab68cc">example</a></div>
           <span>GET /api/v1/characters/CHARACTER_ID</span>
         </td>
         <td>get a specific character by id</td>
       </tr>
       <tr>
         <td class="route">
-          <div class ="example-link"><a href="https://last-airbender-api.herokuapp.com/api/v1/characters/random">example</a></div>
+          <div class ="example-link"><a href="https://last-airbender-api.fly.dev/api/v1/characters/random">example</a></div>
           <span>GET /api/v1/characters/random</span>
         </td>
         <td>get one random character</td>
       </tr>
       <tr>
         <td class="route">
-          <div class ="example-link"><a href="https://last-airbender-api.herokuapp.com/api/v1/characters/random?count=5">example</a></div>
+          <div class ="example-link"><a href="https://last-airbender-api.fly.dev/api/v1/characters/random?count=5">example</a></div>
           <span>GET /api/v1/characters/random?count=NUMBER</span>
         </td>
         <td>get a number of random characters</td>
       </tr>
       <tr>
         <td class="route">
-          <div class ="example-link"><a href="https://last-airbender-api.herokuapp.com/api/v1/characters/avatar">example</a></div>
+          <div class ="example-link"><a href="https://last-airbender-api.fly.dev/api/v1/characters/avatar">example</a></div>
           <span>GET /api/v1/characters/avatar</span>
         </td>
         <td>get all avatars</td>
       </tr>
       <tr>
         <td class="route">
-          <div class ="example-link"><a href="https://last-airbender-api.herokuapp.com/api/v1/characters?affiliation=Fire+Nation">example</a></div>
+          <div class ="example-link"><a href="https://last-airbender-api.fly.dev/api/v1/characters?affiliation=Fire+Nation">example</a></div>
           <span>GET /api/v1/characters?affiliation=NATION+NAME</span>
         </td>
         <td>get characters with a specific affiliation <br/>
@@ -74,21 +74,21 @@
       </tr>
       <tr>
         <td class="route">
-          <div class ="example-link"><a href="https://last-airbender-api.herokuapp.com/api/v1/characters?name=Aang">example</a></div>
+          <div class ="example-link"><a href="https://last-airbender-api.fly.dev/api/v1/characters?name=Aang">example</a></div>
           <span>GET /api/v1/characters?name=CHARACTER+NAME</span>
         </td>
         <td>get characters who's name matches a string</td>
       </tr>
       <tr>
         <td class="route">
-          <div class ="example-link"><a href="https://last-airbender-api.herokuapp.com/api/v1/characters?enemies=Aang">example</a></div>
+          <div class ="example-link"><a href="https://last-airbender-api.fly.dev/api/v1/characters?enemies=Aang">example</a></div>
           <span>GET /api/v1/characters?enemies=CHARACTER+NAME</span>
         </td>
         <td>get characters that are enemies of a specific character</td>
       </tr>
       <tr>
         <td class="route">
-          <div class ="example-link"><a href="https://last-airbender-api.herokuapp.com/api/v1/characters?allies=Aang">example</a></div>
+          <div class ="example-link"><a href="https://last-airbender-api.fly.dev/api/v1/characters?allies=Aang">example</a></div>
           <span>GET /api/v1/characters?allies=CHARACTER+NAME</span>
         </td>
         <td>get characters who are allies of a specific character</td>


### PR DESCRIPTION
I noticed that the README and website examples were still using the herokuapp.com url instead of the new fly.dev url. 

Let me know if there are any issues!